### PR TITLE
CollectVariantCallingMetrics dxapp changes - BunnyNo

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -85,6 +85,15 @@
       "default": false,
       "group": "Picard functions",
       "optional": false
+    },
+    {
+      "name": "run_CollectVariantCallingMetrics",
+      "label": "Choose whether to run Picard CollectVariantCallingMetrics",
+      "help": "Calculate variant calling metrics from a compressed VCF. https://gatk.broadinstitute.org/hc/en-us/articles/360037057132-CollectVariantCallingMetrics-Picard",
+      "class": "boolean",
+      "default": "false",
+      "group": "Picard functions",
+      "optional": false
     }
   ],
   "outputSpec": [

--- a/dxapp.json
+++ b/dxapp.json
@@ -51,6 +51,22 @@
       "optional": true
     },
     {
+      "name": "vcf",
+      "label": "VCF",
+      "help": "VCF containing called variants",
+      "class": "file",
+      "patterns": ["*.vcf.gz"],
+      "optional": true
+    },
+    {
+      "name": "dbsnp_vcf",
+      "label": "dbSNP VCF",
+      "help": "VCF reference file containing dbSNP variants",
+      "class": "file",
+      "patterns": ["*.vcf.gz"],
+      "optional": true
+    },
+    {
       "name": "run_CollectMultipleMetrics",
       "label": "Choose whether to run Picard CollectMultipleMetrics",
       "help": "Specifically, run CollectAlignmentSummaryMetrics, CollectInsertSizeMetrics, QualityScoreDistribution, MeanQualityByCycle, CollectBaseDistributionByCycle, CollectGcBiasMetrics, CollectQualityYieldMetrics. See https://gatk.broadinstitute.org/hc/en-us/articles/360037594031-CollectMultipleMetrics-Picard-",


### PR DESCRIPTION
Changes to support running picard CollectVariantCallingMetrics. Following options added:

- sample VCF
- dbSNP VCF
- flag to activate CollectVariantCallingMetrics

No option for sequence dictionary needed because this comes with the FASTA tar archive bundle, which is already submitted by the user

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_picardqc/17)
<!-- Reviewable:end -->
